### PR TITLE
Bugfix breaking script at start of turn

### DIFF
--- a/main/launch/noAtmoAscent.ks
+++ b/main/launch/noAtmoAscent.ks
@@ -129,7 +129,7 @@ until steeringManager:rollerror <= 0.1 and steeringManager:rollerror >= -0.1
 }
 OutInfo().
 
-until ship:BottomAltRadar >= altStartTurn
+until ship:bounds:BottomAltRadar >= altStartTurn
 {
     DispTelemetry().
     wait 0.01.


### PR DESCRIPTION
'bottomAltRadar' suffix doesn't exist on ship. Changed to ship:bounds:BottomAltRadar. All good now